### PR TITLE
Quote arguments to deal with folders and files that have spaces

### DIFF
--- a/PyMOL.app/Contents/MacOS/PyMOL.sh
+++ b/PyMOL.app/Contents/MacOS/PyMOL.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Start PyMOL with a working directoty which the specified file exists
 if [ -f "$1" ]; then
-    cd $(dirname $1)
+    cd "$(dirname "$1")"
 fi
-/usr/local/bin/pymol $@
+/usr/local/bin/pymol "$@"

--- a/Scripts/PyMOL.sh
+++ b/Scripts/PyMOL.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Start PyMOL with a working directoty which the specified file exists
 if [ -f "$1" ]; then
-    cd $(dirname $1)
+    cd "$(dirname "$1")"
 fi
-/usr/local/bin/pymol $@
+/usr/local/bin/pymol "$@"


### PR DESCRIPTION
Without the quotation marks, PyMOL will not open the file and will
not change into the directory where the file is located.
